### PR TITLE
Adds "--no-ignore" argument

### DIFF
--- a/src/main/scala/codacy/metrics/ESLint.scala
+++ b/src/main/scala/codacy/metrics/ESLint.scala
@@ -62,6 +62,7 @@ object ESLint extends MetricsTool {
     List(
       "eslint",
       "--no-eslintrc",
+      "--no-ignore",
       "-f",
       "checkstyle",
       "--ext",


### PR DESCRIPTION
We are receiving warnings when the repo has a .eslintignore file and we are passing files to be analysed that match the pattern on this file (more info here: https://eslint.org/docs/1.0.0/user-guide/configuring#ignored-file-warnings).

The complexity analysis for javascript files is failing because of this for some projects.