### PR TITLE
test: Add repro for custom plugin crash CY-1824

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,20 @@ workflows:
           persist_to_workspace: true
           requires:
             - codacy/checkout_and_version
+      - codacy/shell:
+          name: test_with_eslintrc
+          cmd: |
+            # codacy-plugins-test can't test metrics with config filters
+            # test if tool ignores custom eslintrc files
+            docker load --input docker-image.tar
+
+            echo "plugins:" > eslint_config
+            echo "  - jest" >> eslint_config
+
+            docker run -v $PWD/docs/tests/:/src -v $PWD/eslint_config:/src/.eslintrc.yaml $CIRCLE_PROJECT_REPONAME:latest
+          persist_to_workspace: true
+          requires:
+            - publish_docker_local
       - codacy_plugins_test/run:
           name: plugins_test
           run_metrics_tests: true
@@ -27,6 +41,7 @@ workflows:
       - codacy/publish_docker:
           context: CodacyDocker
           requires:
+            - test_with_eslintrc
             - plugins_test
           filters:
             branches:

--- a/src/eslintDefaultOptions.ts
+++ b/src/eslintDefaultOptions.ts
@@ -26,5 +26,6 @@ export const defaultOptions: CLIEngine.Options = {
       complexity: [1, 0]
     }
   },
-  cwd: "/src"
+  cwd: "/src",
+  useEslintrc: false
 }


### PR DESCRIPTION
codacy-metrics-eslint is trying to search `.eslintrc` files in the source files to enrich its configuration.
It doesn't need to and, moreover, when the config adds plugins that are not installed, it crashes.